### PR TITLE
[Feat] #56 - 유저 프로필 수정 뷰 및 기능 구현

### DIFF
--- a/src/components/login/Input.jsx
+++ b/src/components/login/Input.jsx
@@ -2,14 +2,15 @@ import React from 'react';
 import styled, { css } from 'styled-components';
 import * as Color from '../../common/Color';
 
-const Input = ({ type, placeholder, value, onChange, hasError }) => {
+const Input = (props) => {
   return (
     <StyledInput
-      type={type}
-      placeholder={placeholder}
-      value={value}
-      onChange={onChange}
-      hasError={hasError}
+      type={props.type}
+      placeholder={props.placeholder}
+      value={props.value}
+      onChange={props.onChange}
+      hasError={props.hasError}
+      disabled={props.disable}
     />
   );
 };

--- a/src/components/login/LoginModal.jsx
+++ b/src/components/login/LoginModal.jsx
@@ -9,11 +9,15 @@ import GoogleIcon from '../../assets/login/googleIcon.svg';
 import GithubIcon from '../../assets/login/githubIcon.svg';
 import EmailIcon from '../../assets/login/mailIcon.svg';
 import CloseBtn from '../../assets/login/closeBtn.svg';
+import { useStore } from 'zustand';
 
 
 export const LoginModal = ({ onClose }) => {
 
   const { setLogin } = useLoginStore();
+  const setEmail = useStore((state) => state.setEmail);
+  const setNickname = useStore((state) => state.setNickname);
+  const setMemberId = useStore((state) => state.setMemberId);
 
   const [ userId, setUserId ] = useState("");
   const [ password, setPassword ] = useState(""); 
@@ -26,10 +30,14 @@ export const LoginModal = ({ onClose }) => {
   
     console.log(data);
     try {
-      const result = await post('/members/login', data);
-      console.log('POST 요청 결과:', result);
-      sessionStorage.setItem("accessToken", result.result.tokenInfo.accessToken);
+      const response = await post('/members/login', data);
+      console.log('POST 요청 결과:', response);
+      sessionStorage.setItem("accessToken", response.result.tokenInfo.accessToken);
       setLogin();
+      setEmail(response.response.email);
+      setNickname(response.response.nickname);
+      setMemberId(response.response.memberId);
+
       window.location.reload();
       alert('로그인 되었습니다.');
     } catch (error) {

--- a/src/components/login/LoginModal.jsx
+++ b/src/components/login/LoginModal.jsx
@@ -3,21 +3,20 @@ import styled from "styled-components";
 import * as Color from '../../common/Color';
 import { post } from '../../common/api';
 import { useLoginStore } from '../../store/LoginStore';
+
 import NaverIcon from '../../assets/login/naverIcon.svg';
 import KakaorIcon from '../../assets/login/kakaoIcon.svg';
 import GoogleIcon from '../../assets/login/googleIcon.svg';
 import GithubIcon from '../../assets/login/githubIcon.svg';
 import EmailIcon from '../../assets/login/mailIcon.svg';
 import CloseBtn from '../../assets/login/closeBtn.svg';
-import { useStore } from 'zustand';
-
 
 export const LoginModal = ({ onClose }) => {
 
   const { setLogin } = useLoginStore();
-  const setEmail = useStore((state) => state.setEmail);
-  const setNickname = useStore((state) => state.setNickname);
-  const setMemberId = useStore((state) => state.setMemberId);
+  const setEmail = useLoginStore((state) => state.setEmail);
+  const setNickname = useLoginStore((state) => state.setNickname);
+  const setMemberId = useLoginStore((state) => state.setMemberId);
 
   const [ userId, setUserId ] = useState("");
   const [ password, setPassword ] = useState(""); 
@@ -34,15 +33,15 @@ export const LoginModal = ({ onClose }) => {
       console.log('POST 요청 결과:', response);
       sessionStorage.setItem("accessToken", response.result.tokenInfo.accessToken);
       setLogin();
-      setEmail(response.response.email);
-      setNickname(response.response.nickname);
-      setMemberId(response.response.memberId);
+      setEmail(response.result.email);
+      setNickname(response.result.nickname);
+      setMemberId(response.result.memberId);
 
       window.location.reload();
       alert('로그인 되었습니다.');
     } catch (error) {
       console.error('POST 요청 실패:', error);
-      alert(`${error.response.message}`);
+      alert(`${error.response}`);
     }
   }
 

--- a/src/components/profile/ModifyProfile.jsx
+++ b/src/components/profile/ModifyProfile.jsx
@@ -10,6 +10,7 @@ import { SignUpBtnBox } from '../signup/SignUpBtnBox';
 
 import { get, post } from "../../common/api";
 import { useLoginStore } from "../../store/LoginStore";
+import { IntroduceInputContainer } from '../signup/IntroduceInputContainer';
 
 
 export const ModifyProfile = () => {
@@ -24,6 +25,7 @@ export const ModifyProfile = () => {
     "github": '',
     "linkedin": '',
     "discord": '',
+    introduction: '',
   });
 
   const [changeFormData, setChangeFormData] = useState({
@@ -48,6 +50,7 @@ export const ModifyProfile = () => {
           github: userData.githubUrl || '',
           linkedin: userData.linkedinUrl || '',
           discord: userData.discordUrl || '',
+          introduction: userData.introduction || '',
         });
 
         if (userData.birth === '1000-01-01') {
@@ -173,6 +176,9 @@ export const ModifyProfile = () => {
           onChange={(value, error) => handleChange('birth', value, error)}
         />
       </St.SignUpContainerWrapper>
+      <IntroduceInputContainer 
+        value={profileFormData.introduction}
+      />
       <SocialInputContainer 
         handleChange={handleChange} 
         github={profileFormData.github}

--- a/src/components/profile/ModifyProfile.jsx
+++ b/src/components/profile/ModifyProfile.jsx
@@ -24,7 +24,7 @@ export const ModifyProfile = () => {
     "github": '',
     "linkedin": '',
     "discord": '',
-    introduction: '',
+    "introduction": '',
   });
 
       // 유저 정보 get api
@@ -182,6 +182,7 @@ export const ModifyProfile = () => {
       </St.SignUpContainerWrapper>
       <IntroduceInputContainer 
         value={profileFormData.introduction}
+        handleChange={handleChange}
       />
       <SocialInputContainer 
         handleChange={handleChange} 
@@ -189,7 +190,11 @@ export const ModifyProfile = () => {
         linkedIn={profileFormData.linkedin}
         discord={profileFormData.discord}  
       />
-      <SignUpBtnBox onSubmit={putUserInfo} title='저장하기' isDisable={false} />
+      <SignUpBtnBox 
+        onSubmit={putUserInfo} 
+        title='저장하기' 
+        isDisable={false} 
+      />
     </St.SignUpWrapper>
   )
 }

--- a/src/components/profile/ModifyProfile.jsx
+++ b/src/components/profile/ModifyProfile.jsx
@@ -27,14 +27,6 @@ export const ModifyProfile = () => {
     introduction: '',
   });
 
-  const [changeFormData, setChangeFormData] = useState({
-    "birth": "",
-    "introduction": "",
-    "github": "",
-    "linkedin": "",
-    "discord": ""
-  });
-
       // 유저 정보 get api
     const getUserInfo = async () => {
       try {
@@ -52,23 +44,22 @@ export const ModifyProfile = () => {
           introduction: userData.introduction || '',
         });
 
-        changeFormData({
-          birth: userData.birth === '1000-01-01'? '' : userData.birth.replaceAll('-', ''),
-          introduction: userData.introduction || '',
-          github: userData.githubUrl || '',
-          linkedin: userData.linkedinUrl || '',
-          discord: userData.discordUrl || '',
-        })
-
         if (userData.birth === '1000-01-01') {
           setProfileFormData({birth: ''});
-          setChangeFormData({birth: ''});
         }
         console.log(profileFormData);
       } catch (error) {
         console.error('회원 정보 가져오기 실패', error);
       }
     }
+
+    const [changeFormData, setChangeFormData] = useState({
+      "birth": profileFormData.birth,
+      "introduction": profileFormData.introduction,
+      "github": profileFormData.github,
+      "linkedin": profileFormData.linkedin,
+      "discord": profileFormData.discord,
+    });
 
     useEffect(() => {
       console.log(memberId);
@@ -108,7 +99,7 @@ export const ModifyProfile = () => {
     }
 
     setChangeFormData({
-      ...changeFormData,
+      ...profileFormData,
       [name]: value,
     });
   };

--- a/src/components/profile/ModifyProfile.jsx
+++ b/src/components/profile/ModifyProfile.jsx
@@ -1,0 +1,208 @@
+import React from 'react'
+import styled from 'styled-components';
+import * as Color from '../../common/Color';
+import { useState, useEffect } from 'react';
+
+import SignUpTitle from '../signup/SignUpTitle';
+import { SignUpInputContainer } from '../signup/SignUpInputContainer';
+import { SocialInputContainer } from '../signup/SocialInputContainer';
+import { SignUpBtnBox } from '../signup/SignUpBtnBox';
+
+import { get, post } from "../../common/api";
+import { useLoginStore } from "../../store/LoginStore";
+
+
+export const ModifyProfile = () => {
+
+  const memberId = useLoginStore((state) => state.memberId);
+
+  const [profileFormData, setProfileFormData] = useState({
+    "email": '',
+    "password": '************',
+    "nickname": '',
+    "birth": '',
+    "github": '',
+    "linkedin": '',
+    "discord": '',
+  });
+
+  const [changeFormData, setChangeFormData] = useState({
+    "birth": "",
+    "introduction": "",
+    "github": "",
+    "linkedin": "",
+    "discord": ""
+  });
+
+      // 유저 정보 get api
+    const getUserInfo = async () => {
+      try {
+        const response = await get(`/members/info`);  // 회원 정보를 가져오는 API
+        const userData = response.result;
+        console.log(response.result);
+        setProfileFormData({
+          email: userData.email,
+          password: userData.password,  
+          nickname: userData.nickname,
+          birth: userData.birth === '1000-01-01' ? '' : userData.birth.replaceAll('-', ''),
+          github: userData.githubUrl || '',
+          linkedin: userData.linkedinUrl || '',
+          discord: userData.discordUrl || '',
+        });
+
+        if (userData.birth === '1000-01-01') {
+          setProfileFormData({birth: ''});
+        }
+        console.log(profileFormData);
+      } catch (error) {
+        console.error('회원 정보 가져오기 실패', error);
+      }
+    }
+
+    useEffect(() => {
+      console.log(memberId);
+      if (memberId) {
+        getUserInfo();
+      }
+    }, [memberId]);
+
+  const [errors, setErrors] = useState({
+    nickname: '',
+    birth: ''
+  });
+
+  const [isNicknameChecked, setIsNicknameChecked] = useState(false);
+
+  const handleChange = (name, value, error) => {
+    if (name === 'birth') {
+      value = birthFormatDate(value);
+    }
+
+    setProfileFormData({
+      ...profileFormData,
+      [name]: value,
+    });
+    setErrors({
+      ...errors,
+      [name]: error,
+    });
+
+        // 닉네임 변경되었을 시 초기화
+    if (name === 'nickname') {
+      setIsNicknameChecked(false);
+    }
+  };
+
+    // 유저 정보 수정 api
+  const handleSubmit = async () => {
+    try {
+      if (Object.values(errors).some(error => error)) {
+        console.error('폼 형식이 알맞지 않습니다.');
+        return;
+      } else if (!isNicknameChecked) {
+        alert('닉네임 중복 확인이 필요합니다.');
+        return;
+      }
+      const response = await post('/members/sign-up', profileFormData);
+      console.log('회원가입 성공', response);
+      console.log(profileFormData);
+    } catch (error) {
+      console.error('회원가입 실패', error);
+      console.log(profileFormData);
+    }
+  }
+
+    // 생년월일 포맷
+  const birthFormatDate = (date) => {
+    const year = date.slice(0, 4);
+    const month = date.slice(4, 6);
+    const day = date.slice(6, 8);
+
+    return `${year}-${month}-${day}`;
+  }
+
+  const [isDisabled, setIsDisabled] = useState(true);
+
+  useEffect(() => {
+    const hasErrors = Object.values(errors).some(error => error);
+    const requiredFields = ['email', 'password', 'nickname'];
+    const hasEmptyFields = requiredFields.some(field => !profileFormData[field]);
+    const disable = hasErrors || hasEmptyFields;
+    setIsDisabled(disable);
+  }, [profileFormData, errors]);
+
+  return (
+    <St.SignUpWrapper>
+      <SignUpTitle>내 정보</SignUpTitle>
+      <St.SignUpContainerWrapper>
+        <SignUpInputContainer
+          title='이메일'
+          essential={Boolean(true)}
+          type='text'
+          value={profileFormData.email}
+          isButtonHidden={Boolean(false)}
+          disable={true}
+          onChange={() => {}}
+        />
+        <SignUpInputContainer
+          title='비밀번호'
+          essential={Boolean(true)}
+          type='password'
+          value={profileFormData.password}
+          isButtonHidden={Boolean(true)}
+          disable={true}
+          onChange={() => {}}
+        />
+        <SignUpInputContainer
+          title='닉네임'
+          essential={Boolean(true)}
+          type='text'
+          placeholder='사용자 닉네임을 입력해주세요.'
+          value={profileFormData.nickname}
+          isButtonHidden={Boolean(false)}
+          onChange={(value, error) => handleChange('nickname', value, error)}
+          onCheckDuplicate={() => setIsNicknameChecked(true)}
+        />
+        <SignUpInputContainer
+          title='생년월일'
+          essential={Boolean(false)}
+          type='text'
+          placeholder='YYYYDDMM'
+          value={profileFormData.birth}
+          isButtonHidden={Boolean(true)}
+          onChange={(value, error) => handleChange('birth', value, error)}
+        />
+      </St.SignUpContainerWrapper>
+      <SocialInputContainer 
+        handleChange={handleChange} 
+        github={profileFormData.github}
+        linkedIn={profileFormData.linkedin}
+        discord={profileFormData.discord}  
+      />
+      <SignUpBtnBox onSubmit={handleSubmit} isDisabled={isDisabled} />
+    </St.SignUpWrapper>
+  )
+}
+
+const St = {
+
+  SignUpWrapper: styled.div`
+    width: 100%;
+    height: 100%;
+    position: flex;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    background-color: ${Color.background};
+    padding-bottom: 126px;
+  `,
+
+  SignUpContainerWrapper: styled.div`
+    display: flex;
+    align-items: center;
+    margin-top: 48px;
+    flex-direction: column;
+  `,
+}
+

--- a/src/components/signup/IntroduceInputContainer.jsx
+++ b/src/components/signup/IntroduceInputContainer.jsx
@@ -3,12 +3,14 @@ import styled, { css } from 'styled-components';
 import * as Color from '../../common/Color';
 
 export const IntroduceInputContainer = (props) => {
+
     return (
         <St.IntroduceConatinerWrapper>
             <St.IntroduceTitle>내 소개</St.IntroduceTitle>
             <St.IntroduceInput
                 placeholder='소개글'
                 value={props.value}
+                onChange={(e) => props.handleChange("introduction", e.target.value, '')}
             />
         </St.IntroduceConatinerWrapper>
     );

--- a/src/components/signup/IntroduceInputContainer.jsx
+++ b/src/components/signup/IntroduceInputContainer.jsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import styled, { css } from 'styled-components';
+import * as Color from '../../common/Color';
+
+export const IntroduceInputContainer = (props) => {
+    return (
+        <St.IntroduceConatinerWrapper>
+            <St.IntroduceTitle>내 소개</St.IntroduceTitle>
+            <St.IntroduceInput
+                placeholder='소개글'
+                value={props.value}
+            />
+        </St.IntroduceConatinerWrapper>
+    );
+};
+
+const St = {
+    IntroduceConatinerWrapper: styled.div`
+        display: flex;
+        width: 780px;
+        margin-bottom: 48px;
+    `,
+
+    IntroduceInput: styled.textarea`
+        background-color: ${Color.gray700};
+        color: ${Color.gray300};
+        width: 390px;
+        height: 110px;
+        font-family: 'D2Coding';
+        border: none;
+        border-radius: 10px;
+        font-size: 18px;
+        line-height: 22px;
+        outline: none;
+        padding: 16px;
+        resize: none;
+
+        &::placeholder {
+            color: ${Color.gray300};
+        }
+    `,
+
+    IntroduceTitle: styled.h1`
+        font-family: Pretendard;
+        font-size: 20px;
+        font-weight: 500;
+        line-height: 32px;
+        color: ${Color.text1};
+        margin-left: 0px;
+        margin-right: 120px;
+        margin-top: 12px;
+    `,
+
+
+}

--- a/src/components/signup/SignUp.jsx
+++ b/src/components/signup/SignUp.jsx
@@ -138,7 +138,7 @@ export const SignUp = () => {
         />
       </St.SignUpContainerWrapper>
       <SocialInputContainer handleChange={handleChange} />
-      <SignUpBtnBox onSubmit={handleSubmit} isDisabled={isDisabled} />
+      <SignUpBtnBox onSubmit={handleSubmit} isDisabled={isDisabled} title='회원가입'/>
     </St.SignUpWrapper>
   )
 }

--- a/src/components/signup/SignUp.jsx
+++ b/src/components/signup/SignUp.jsx
@@ -15,7 +15,7 @@ export const SignUp = () => {
     "email": '',
     "password": '',
     "nickname": '',
-    "birth": '0000-00-00',
+    "birth": '1000-01-01',
     "gender": 'Male',
     "github": '',
     "linkedin": '',
@@ -70,10 +70,12 @@ export const SignUp = () => {
       const response = await post('/members/sign-up', signUpFormData);
       console.log('회원가입 성공', response);
       console.log(signUpFormData);
+      alert('회원가입 성공');
       // 뷰 이동?
     } catch (error) {
-      console.error('회원가입 실패', error);
+      console.error('회원가입 실패', error.response);
       console.log(signUpFormData);
+      alert('회원가입 실패');
     }
   }
 

--- a/src/components/signup/SignUp.jsx
+++ b/src/components/signup/SignUp.jsx
@@ -15,7 +15,7 @@ export const SignUp = () => {
     "email": '',
     "password": '',
     "nickname": '',
-    "birth": '2024-08-12',
+    "birth": '0000-00-00',
     "gender": 'Male',
     "github": '',
     "linkedin": '',

--- a/src/components/signup/SignUpBtnBox.jsx
+++ b/src/components/signup/SignUpBtnBox.jsx
@@ -2,11 +2,10 @@ import React from 'react'
 import styled from 'styled-components'
 import * as Color from '../../common/Color';
 
-export const SignUpBtnBox = ({ onSubmit, isDisabled }) => {
-  console.log(isDisabled);
+export const SignUpBtnBox = (props) => {
   return (
     <St.SignUpBtnBoxWrapper>
-      <St.SignUpButton title='회원가입' onClick={onSubmit} disabled={isDisabled}>회원가입</St.SignUpButton>
+      <St.SignUpButton onClick={props.onSubmit} disabled={props.isDisabled}>{props.title}</St.SignUpButton>
       <St.BackButton title='뒤로가기'>뒤로가기</St.BackButton>
     </St.SignUpBtnBoxWrapper>
   )

--- a/src/components/signup/SignUpInputContainer.jsx
+++ b/src/components/signup/SignUpInputContainer.jsx
@@ -8,16 +8,16 @@ import { CheckDuplicateBtn } from './CheckDuplicateBtn';
 
 import { get } from "../../common/api";
 
-export const SignUpInputContainer = ({ title, essential, type, placeholder, isButtonHidden, onChange, onCheckDuplicate }) => {
+export const SignUpInputContainer = (props) => {
   const [value, setValue] = useState('');
   const [error, setError] = useState('');
 
   const validateInput = (value) => {
-    if (essential && !value) {
+    if (props.essential && !value) {
       return '필수 입력 항목입니다.';
     }
 
-    switch (title) {
+    switch (props.title) {
       case '이메일':
         const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
         return emailRegex.test(value) ? '' : '올바른 형식이 아닙니다';
@@ -37,21 +37,21 @@ export const SignUpInputContainer = ({ title, essential, type, placeholder, isBu
     setValue(value);
     const validationError = validateInput(value);
     setError(validationError);
-    onChange(value, validationError);
+    props.onChange(value, validationError);
   };
 
   const checkRedundancyAPI = async () => {
     console.log(value);
     try {
-      const response = title === '이메일'
+      const response = props.title === '이메일'
         ? await get(`/members/sign-up/check-email?email=${value}`)
         : await get(`/members/sign-up/check-nickname?nickname=${value}`);
 
       console.log(response);
 
       if (response.isSuccess) {
-        alert(`사용 가능한 ${title}입니다.`);
-        onCheckDuplicate();
+        alert(`사용 가능한 ${props.title}입니다.`);
+        props.onCheckDuplicate();
       } else {
         setError(response.message);
       }
@@ -66,19 +66,20 @@ export const SignUpInputContainer = ({ title, essential, type, placeholder, isBu
 
   return (
     <St.SignUpInputContainerWrapper>
-      <SignUpInputTitle title={title} essential={essential} />
+      <SignUpInputTitle title={props.title} essential={props.essential} />
       <St.InputAndButtonWrapper>
         <St.SignUpInputWrapper>
           <Input
-            type={type}
-            placeholder={placeholder}
-            value={value}
+            type={props.type}
+            placeholder={props.placeholder}
+            value={props.value}
             onChange={handleChange}
             hasError={!!error}
+            disable={props.disable || false}
           />
           {error && <St.ErrorText>{error}</St.ErrorText>}
         </St.SignUpInputWrapper>
-        {!isButtonHidden && <CheckDuplicateBtn onClick={checkRedundancyAPI} />}
+        {!props.isButtonHidden && <CheckDuplicateBtn onClick={checkRedundancyAPI} />}
       </St.InputAndButtonWrapper>
     </St.SignUpInputContainerWrapper>
   );

--- a/src/components/signup/SocialInputBox.jsx
+++ b/src/components/signup/SocialInputBox.jsx
@@ -2,16 +2,17 @@ import React from 'react'
 import styled from 'styled-components'
 import * as Color from '../../common/Color'
 
-export const SocialInputBox = ({ image, placeholder, onChange }) => {
+export const SocialInputBox = (props) => {
   const handleInputChange = (event) => {
-    onChange(event.target.value);
+    props.onChange(event.target.value);
   };
 
   return (
     <St.SocialInputWrapper>
-      <St.SocialInputIcon>{image}</St.SocialInputIcon>
+      <St.SocialInputIcon>{props.image}</St.SocialInputIcon>
       <St.SocialInput
-        placeholder={placeholder}
+        placeholder={props.placeholder}
+        value={props.value}
         onChange={handleInputChange}
       />
     </St.SocialInputWrapper>

--- a/src/components/signup/SocialInputContainer.jsx
+++ b/src/components/signup/SocialInputContainer.jsx
@@ -6,7 +6,7 @@ import linkedInIcon from '../../assets/signUp/linkedin.svg'
 import discordIcon from '../../assets/signUp/discord.svg'
 import { SignUpInputTitle } from './SignUpInputTitle'
 
-export const SocialInputContainer = ({ handleChange }) => {
+export const SocialInputContainer = (props) => {
   return (
     <>
       <St.SocialInputContainerWrapper>
@@ -17,21 +17,24 @@ export const SocialInputContainer = ({ handleChange }) => {
         <SocialInputBox
           image={<img src={githubIcon} alt="Github" />}
           placeholder='id를 입력해주세요.'
-          onChange={(value) => handleChange('github', value, '')}
+          value={props.github}
+          onChange={(value) => props.handleChange('github', value, '')}
         />
       </St.SocialInputContainerWrapper>
       <St.SocialInputWithoutTitleWrapper>
         <SocialInputBox
           image={<img src={linkedInIcon} alt="linkedIn" />}
           placeholder='id를 입력해주세요.'
-          onChange={(value) => handleChange('linkedin', value, '')}
+          value={props.linkedIn}
+          onChange={(value) => props.handleChange('linkedin', value, '')}
         />
       </St.SocialInputWithoutTitleWrapper>
       <St.SocialInputWithoutTitleWrapper>
         <SocialInputBox
           image={<img src={discordIcon} alt="discord" />}
           placeholder='id를 입력해주세요.'
-          onChange={(value) => handleChange('discord', value, '')}
+          value={props.discord}
+          onChange={(value) => props.handleChange('discord', value, '')}
         />
       </St.SocialInputWithoutTitleWrapper>
     </>

--- a/src/store/LoginStore.js
+++ b/src/store/LoginStore.js
@@ -3,5 +3,12 @@ import { create } from 'zustand'
 export const useLoginStore = create((set) => ({
     isLogin: false,
     setLogin: () => set({ isLogin: true }),
-    setLogout: () => set({ isLogin: false })
+    setLogout: () => set({ isLogin: false }),
+
+    email: null,
+    setEmail: (email) => set({ email: email }),
+    nickname: null,
+    setNickname: (nickname) => set({ nickname: nickname }),
+    memberId: null,
+    setMemberId: (id) => ({ memberId: id }),
 }));

--- a/src/store/LoginStore.js
+++ b/src/store/LoginStore.js
@@ -1,14 +1,31 @@
 import { create } from 'zustand'
+import { persist } from 'zustand/middleware'
 
-export const useLoginStore = create((set) => ({
-    isLogin: false,
-    setLogin: () => set({ isLogin: true }),
-    setLogout: () => set({ isLogin: false }),
+export const useLoginStore = create(
+    persist(
+        (set) => ({
+            isLogin: false,
+            setLogin: () => set({ isLogin: true }),
+            setLogout: () => set({ 
+                isLogin: false ,
+                email: null,
+                nickname: null,
+                memberId: null,
+            }),
+        
+            email: null,
+            setEmail: (email) => set({ email: email }),
+            nickname: null,
+            setNickname: (nickname) => set({ nickname: nickname }),
+            memberId: null,
+            setMemberId: (id) => {
+                const memberId = String(id);
+                set({ memberId });
+                console.log(memberId); }
+            }),
+            {
+                name: "userInfoStorage",
+            }
+    )
+);
 
-    email: null,
-    setEmail: (email) => set({ email: email }),
-    nickname: null,
-    setNickname: (nickname) => set({ nickname: nickname }),
-    memberId: null,
-    setMemberId: (id) => ({ memberId: id }),
-}));


### PR DESCRIPTION
## 🌳 작업한 내용

<!-- 아래 리스트를 지우고, 작업 내용을 적어주세요. -->
- 유저 프로필 수정 뷰 구현
- api 작업

## 💭 PR POINT

<!-- 덧붙이고 싶은 내용이 있다면! -->
```
import { create } from 'zustand'
import { persist } from 'zustand/middleware'

export const useLoginStore = create(
    persist(
        (set) => ({
            isLogin: false,
            setLogin: () => set({ isLogin: true }),
            setLogout: () => set({ 
                isLogin: false ,
                email: null,
                nickname: null,
                memberId: null,
            }),
        
            email: null,
            setEmail: (email) => set({ email: email }),
            nickname: null,
            setNickname: (nickname) => set({ nickname: nickname }),
            memberId: null,
            setMemberId: (id) => {
                const memberId = String(id);
                set({ memberId });
                console.log(memberId); }
            }),
            {
                name: "userInfoStorage",
            }
    )
);
```
로그인 시 이메일, 닉네임, 멤버 아이디 저장하도록 만들었는데, 필요하시면 `LoginStore.js` 선언하시고
`const memberId = useLoginStore((state) => state.memberId);`
와 같은 식으로 가져와 사용하실 수 있습니다!

## 📷 스크린샷

<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->

|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
| GIF | <img src = "https://github.com/user-attachments/assets/e1cc252b-7165-49cc-a8d1-d7d876957e16" width ="1000">|

## 🌈 관련 이슈

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. 수고했습니다~* -->
- Resolved: #56 